### PR TITLE
Add GitHub Skills activity to the API

### DIFF
--- a/.github/steps/4-step.md
+++ b/.github/steps/4-step.md
@@ -11,7 +11,7 @@ While AI assistants like GitHub Copilot can dramatically improve productivity, i
 
 1. Open the new pull request created by Copilot in a new tab.
 
-   [![Examine the pull request](https://img.shields.io/badge/-Open%20Pull%20Request-1f883d?logo=github)]({{{pull_request_url}}})
+   [![Examine the pull request](https://img.shields.io/badge/-Open%20Pull%20Request-1f883d?logo=github)](${{ pull_request_url }})
 
    > ✨ **Bonus:** If your Copilot subscription provides it, you can also use a specialised version of Copilot to [review the changes](https://docs.github.com/en/copilot/using-github-copilot/code-review/using-copilot-code-review?tool=webui).
 

--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub",
+        "schedule": "Mondays, 3:30 PM - 4:30 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
This pull request adds the 'GitHub Skills' activity to the API, allowing students to register for this new activity. The activity includes a description, schedule, and a maximum number of participants.